### PR TITLE
Add Price to the Order model of FlightManagement module.

### DIFF
--- a/common/types/src/main/java/com/enterprise/airport/common/types/common/Price.java
+++ b/common/types/src/main/java/com/enterprise/airport/common/types/common/Price.java
@@ -1,4 +1,4 @@
-package com.enterprise.airport.flightmanagement.domain.ticket;
+package com.enterprise.airport.common.types.common;
 
 import com.enterprise.airport.common.types.exception.DomainException;
 import lombok.AccessLevel;

--- a/flightManagement/domain/src/main/java/com/enterprise/airport/flightmanagement/domain/order/Order.java
+++ b/flightManagement/domain/src/main/java/com/enterprise/airport/flightmanagement/domain/order/Order.java
@@ -2,11 +2,13 @@ package com.enterprise.airport.flightmanagement.domain.order;
 
 import com.enterprise.airport.common.types.base.AggregateRoot;
 import com.enterprise.airport.common.types.base.Version;
+import com.enterprise.airport.common.types.common.Price;
 import com.enterprise.airport.common.types.exception.DomainException;
 import com.enterprise.airport.flightmanagement.domain.ticket.Ticket;
 import com.enterprise.airport.flightmanagement.domain.ticket.TicketAvailable;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -16,18 +18,21 @@ public class Order extends AggregateRoot<OrderId> {
     private List<OrderItem> orderItems;
     private Email customerEmail;
     private OrderStatus status;
+    private Price price;
 
     public Order(
             OrderId id,
             Version first,
             List<OrderItem> orderItems,
             Email customerEmail,
-            OrderStatus status
+            OrderStatus status,
+            Price price
     ) {
         super(id, first);
         this.orderItems = orderItems;
         this.customerEmail = customerEmail;
         this.status = status;
+        this.price = price;
     }
 
     public void pay() {
@@ -65,12 +70,21 @@ public class Order extends AggregateRoot<OrderId> {
                         .collect(Collectors.toList()
                 ),
                 customerEmail,
-                OrderStatus.CREATED
+                OrderStatus.CREATED,
+                calcTotalPrice(passengers)
         );
 
         createdOrder.addEvent(new OrderEvent.OrderCreated(createdOrder.getId()));
 
         return createdOrder;
+    }
+
+    private static Price calcTotalPrice(Map<Ticket, Passenger> passengers) {
+        return passengers.keySet().stream()
+                .map(ticket -> ticket.getPrice().getValue())
+                .reduce(BigDecimal::add)
+                .map(Price::from)
+                .orElseThrow();
     }
 
     public static class TicketIsNotAvailableException extends DomainException {

--- a/flightManagement/domain/src/main/java/com/enterprise/airport/flightmanagement/domain/order/OrderRestorer.java
+++ b/flightManagement/domain/src/main/java/com/enterprise/airport/flightmanagement/domain/order/OrderRestorer.java
@@ -1,6 +1,7 @@
 package com.enterprise.airport.flightmanagement.domain.order;
 
 import com.enterprise.airport.common.types.base.Version;
+import com.enterprise.airport.common.types.common.Price;
 
 import java.util.List;
 
@@ -13,8 +14,9 @@ public final class OrderRestorer {
             Version first,
             List<OrderItem> orderItems,
             Email customerEmail,
-            OrderStatus status
+            OrderStatus status,
+            Price price
     ) {
-        return new Order(id, first, orderItems, customerEmail, status);
+        return new Order(id, first, orderItems, customerEmail, status, price);
     }
 }

--- a/flightManagement/domain/src/main/java/com/enterprise/airport/flightmanagement/domain/ticket/Ticket.java
+++ b/flightManagement/domain/src/main/java/com/enterprise/airport/flightmanagement/domain/ticket/Ticket.java
@@ -2,6 +2,7 @@ package com.enterprise.airport.flightmanagement.domain.ticket;
 
 import com.enterprise.airport.common.types.base.AggregateRoot;
 import com.enterprise.airport.common.types.base.Version;
+import com.enterprise.airport.common.types.common.Price;
 import com.enterprise.airport.common.types.exception.DomainException;
 import com.enterprise.airport.flightmanagement.domain.flight.Flight;
 import com.enterprise.airport.flightmanagement.domain.flight.FlightId;

--- a/flightManagement/domain/src/main/java/com/enterprise/airport/flightmanagement/domain/ticket/TicketRestorer.java
+++ b/flightManagement/domain/src/main/java/com/enterprise/airport/flightmanagement/domain/ticket/TicketRestorer.java
@@ -1,6 +1,7 @@
 package com.enterprise.airport.flightmanagement.domain.ticket;
 
 import com.enterprise.airport.common.types.base.Version;
+import com.enterprise.airport.common.types.common.Price;
 import com.enterprise.airport.flightmanagement.domain.flight.FlightId;
 
 public final class TicketRestorer {

--- a/flightManagement/domain/src/test/java/com/enterprise/airport/flightmanagement/domain/Fixtures.java
+++ b/flightManagement/domain/src/test/java/com/enterprise/airport/flightmanagement/domain/Fixtures.java
@@ -3,6 +3,7 @@ package com.enterprise.airport.flightmanagement.domain;
 import com.enterprise.airport.common.types.base.Version;
 import com.enterprise.airport.common.types.common.AircraftModel;
 import com.enterprise.airport.common.types.common.Airport;
+import com.enterprise.airport.common.types.common.Price;
 import com.enterprise.airport.flightmanagement.domain.aircraft.Aircraft;
 import com.enterprise.airport.flightmanagement.domain.aircraft.AircraftId;
 import com.enterprise.airport.flightmanagement.domain.aircraft.AircraftRestorer;
@@ -18,7 +19,6 @@ import com.enterprise.airport.flightmanagement.domain.order.OrderRestorer;
 import com.enterprise.airport.flightmanagement.domain.order.OrderStatus;
 import com.enterprise.airport.flightmanagement.domain.order.Passenger;
 import com.enterprise.airport.flightmanagement.domain.order.PassportNumber;
-import com.enterprise.airport.flightmanagement.domain.ticket.Price;
 import com.enterprise.airport.flightmanagement.domain.ticket.Ticket;
 import com.enterprise.airport.flightmanagement.domain.ticket.TicketId;
 import com.enterprise.airport.flightmanagement.domain.ticket.TicketRestorer;
@@ -85,8 +85,13 @@ public class Fixtures {
                     ));
                 }},
                 new Email("qwer@tutut.ba"),
-                OrderStatus.CREATED
+                OrderStatus.CREATED,
+                Price.from(BigDecimal.valueOf(randomPositiveLong()).setScale(2))
         );
+    }
+
+    private static long randomPositiveLong() {
+        return Math.abs(RANDOM.nextLong());
     }
 
     public static Passenger generatePassenger() {

--- a/flightManagement/domain/src/test/java/com/enterprise/airport/flightmanagement/domain/order/OrderTest.java
+++ b/flightManagement/domain/src/test/java/com/enterprise/airport/flightmanagement/domain/order/OrderTest.java
@@ -1,9 +1,11 @@
 package com.enterprise.airport.flightmanagement.domain.order;
 
+import com.enterprise.airport.common.types.common.Price;
 import com.enterprise.airport.flightmanagement.domain.Fixtures;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 
 class OrderTest {
@@ -56,6 +58,15 @@ class OrderTest {
                         orderItem -> orderItem.getBookedTicketId().equals(tickets.get(2).getId())
                                 && orderItem.getPassenger().equals(passenger3)
                 )
+        );
+        //AND order has a Price == sum(all ticket prices)
+        Assertions.assertEquals(
+                tickets.stream()
+                        .map(ticket -> ticket.getPrice().getValue())
+                        .reduce(BigDecimal::add)
+                        .map(Price::from)
+                        .get(),
+                order.getPrice()
         );
     }
 

--- a/flightManagement/domain/src/test/java/com/enterprise/airport/flightmanagement/domain/ticket/PriceTest.java
+++ b/flightManagement/domain/src/test/java/com/enterprise/airport/flightmanagement/domain/ticket/PriceTest.java
@@ -1,5 +1,6 @@
 package com.enterprise.airport.flightmanagement.domain.ticket;
 
+import com.enterprise.airport.common.types.common.Price;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/flightManagement/domain/src/test/java/com/enterprise/airport/flightmanagement/domain/ticket/TicketTest.java
+++ b/flightManagement/domain/src/test/java/com/enterprise/airport/flightmanagement/domain/ticket/TicketTest.java
@@ -1,6 +1,7 @@
 package com.enterprise.airport.flightmanagement.domain.ticket;
 
 
+import com.enterprise.airport.common.types.common.Price;
 import com.enterprise.airport.flightmanagement.domain.Fixtures;
 import com.enterprise.airport.flightmanagement.domain.flight.Flight;
 import com.enterprise.airport.flightmanagement.domain.flight.FlightIsAnnounced;

--- a/flightManagement/usecase/src/main/java/com/enterprise/airport/flightmanagement/usecase/ticket/PublishTicketRequest.java
+++ b/flightManagement/usecase/src/main/java/com/enterprise/airport/flightmanagement/usecase/ticket/PublishTicketRequest.java
@@ -1,7 +1,7 @@
 package com.enterprise.airport.flightmanagement.usecase.ticket;
 
+import com.enterprise.airport.common.types.common.Price;
 import com.enterprise.airport.flightmanagement.domain.flight.FlightId;
-import com.enterprise.airport.flightmanagement.domain.ticket.Price;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 

--- a/flightManagement/usecase/src/test/java/com/enterprise/airport/flightmanagement/usecase/Fixtures.java
+++ b/flightManagement/usecase/src/test/java/com/enterprise/airport/flightmanagement/usecase/Fixtures.java
@@ -3,6 +3,7 @@ package com.enterprise.airport.flightmanagement.usecase;
 import com.enterprise.airport.common.types.base.Version;
 import com.enterprise.airport.common.types.common.AircraftModel;
 import com.enterprise.airport.common.types.common.Airport;
+import com.enterprise.airport.common.types.common.Price;
 import com.enterprise.airport.flightmanagement.domain.aircraft.Aircraft;
 import com.enterprise.airport.flightmanagement.domain.aircraft.AircraftId;
 import com.enterprise.airport.flightmanagement.domain.aircraft.AircraftRestorer;
@@ -18,7 +19,6 @@ import com.enterprise.airport.flightmanagement.domain.order.OrderRestorer;
 import com.enterprise.airport.flightmanagement.domain.order.OrderStatus;
 import com.enterprise.airport.flightmanagement.domain.order.Passenger;
 import com.enterprise.airport.flightmanagement.domain.order.PassportNumber;
-import com.enterprise.airport.flightmanagement.domain.ticket.Price;
 import com.enterprise.airport.flightmanagement.domain.ticket.Ticket;
 import com.enterprise.airport.flightmanagement.domain.ticket.TicketId;
 import com.enterprise.airport.flightmanagement.domain.ticket.TicketRestorer;
@@ -110,7 +110,8 @@ public class Fixtures {
                     ));
                 }},
                 new Email("qwer@tutut.ba"),
-                OrderStatus.CREATED
+                OrderStatus.CREATED,
+                Price.from(BigDecimal.valueOf(randomPositiveLong()).setScale(2))
         );
     }
 
@@ -128,7 +129,8 @@ public class Fixtures {
                     ));
                 }},
                 new Email("qwer@tutut.ba"),
-                OrderStatus.CREATED
+                OrderStatus.CREATED,
+                Price.from(BigDecimal.valueOf(randomPositiveLong()).setScale(2))
         );
     }
 
@@ -156,5 +158,9 @@ public class Fixtures {
                         ticket -> ticket.getId().getValue(),
                         ticket -> Fixtures.generatePassengerDto()
                 ));
+    }
+
+    private static long randomPositiveLong() {
+        return Math.abs(RANDOM.nextLong());
     }
 }

--- a/flightManagement/usecase/src/test/java/com/enterprise/airport/flightmanagement/usecase/ticket/PublishTicketRequestTest.java
+++ b/flightManagement/usecase/src/test/java/com/enterprise/airport/flightmanagement/usecase/ticket/PublishTicketRequestTest.java
@@ -1,6 +1,6 @@
 package com.enterprise.airport.flightmanagement.usecase.ticket;
 
-import com.enterprise.airport.flightmanagement.domain.ticket.Price;
+import com.enterprise.airport.common.types.common.Price;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Я то реализовал. Но никак не пойму зачем. В заказе же есть ид-ки всех билетов. Следовательо цену на оплату можно высчитать на лету. ПО ид-кам билетов вычислять билеты и их цены.

Единственное, что приходит в голову. Это когда цена билета меняется. А клиент создал заказ еще по старой цене.